### PR TITLE
Fix for GitHub Pages Deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,5 +28,5 @@ jobs:
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
-        FOLDER: build
+        FOLDER: out
         CLEAN: true


### PR DESCRIPTION
The default GitHub Pages Deployment action was using the output folder `build`. We need it to use `out` since this is what directory Next.js to.